### PR TITLE
STEP-14 캐싱적용 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/study/ecommerce/EcommerceApplication.java
+++ b/src/main/java/com/study/ecommerce/EcommerceApplication.java
@@ -2,7 +2,6 @@ package com.study.ecommerce;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
 public class EcommerceApplication {

--- a/src/main/java/com/study/ecommerce/common/config/RedisConfig.java
+++ b/src/main/java/com/study/ecommerce/common/config/RedisConfig.java
@@ -1,0 +1,55 @@
+package com.study.ecommerce.common.config;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.study.ecommerce.common.constant.CacheConstants;
+
+@Configuration
+@EnableCaching
+@EnableRedisRepositories
+public class RedisConfig {
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+		return redisTemplate;
+	}
+
+	@Bean
+	public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+		RedisCacheConfiguration defaultCacheConfig  = RedisCacheConfiguration.defaultCacheConfig()
+			.entryTtl(Duration.ofMinutes(10))
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+		Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+		// 인기상품 조회는 TTL 1시간
+		cacheConfigurations.put(CacheConstants.POPULAR_PRODUCTS_CACHE, defaultCacheConfig.entryTtl(Duration.ofHours(1)));
+		// 상품목록 조회는 TTL 10분
+		cacheConfigurations.put(CacheConstants.PRODUCTS_ALL, defaultCacheConfig.entryTtl(Duration.ofMinutes(10)));
+
+		return RedisCacheManager.builder(redisConnectionFactory)
+			.cacheDefaults(defaultCacheConfig )
+			.withInitialCacheConfigurations(cacheConfigurations)
+			.build();
+	}
+
+}

--- a/src/main/java/com/study/ecommerce/common/constant/CacheConstants.java
+++ b/src/main/java/com/study/ecommerce/common/constant/CacheConstants.java
@@ -1,0 +1,9 @@
+package com.study.ecommerce.common.constant;
+
+public class CacheConstants {
+	public static final String POPULAR_PRODUCTS_CACHE = "popularProducts";
+	public static final String RECENT_3_DAY_TOP_5_KEY = "'recent3DayTop5'";
+
+	public static final String PRODUCTS_CACHE = "products";
+	public static final String PRODUCTS_ALL = "'all'";
+}

--- a/src/main/java/com/study/ecommerce/domain/product/ProductRepository.java
+++ b/src/main/java/com/study/ecommerce/domain/product/ProductRepository.java
@@ -1,13 +1,11 @@
 package com.study.ecommerce.domain.product;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository {
-	Optional<Product> getInventory(Long id);
 
 	List<Product> getList();
 
@@ -16,4 +14,8 @@ public interface ProductRepository {
 	List<ProductInventory> getInventoryList(Long... ids);
 
 	List<ProductInfo.OrderAmount> getOrderAmountByRecent3DayAndTop5();
+
+	Product getById(Long productId);
+
+	ProductInventory getInventoryByProductId(Long productId);
 }

--- a/src/main/java/com/study/ecommerce/domain/product/ProductService.java
+++ b/src/main/java/com/study/ecommerce/domain/product/ProductService.java
@@ -4,10 +4,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
+import com.study.ecommerce.common.constant.CacheConstants;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProductService {
@@ -15,12 +20,13 @@ public class ProductService {
 	private final ProductRepository productRepository;
 
 	/**
-	 * <h1>제품 정보 상세 조회</h1>
+	 * <h1>제품 정보 상세목록 조회</h1>
 	 * <ul>
 	 *     <li>코드는 복잡해보이지만 별거 없다.</li>
 	 *     <li>1대1 관계로 Product 와 ProductInventory 가 있는데 이를 매핑 시켜줄 뿐이다.</li>
 	 * </ul>
 	 */
+	@Cacheable(value = CacheConstants.PRODUCTS_CACHE, key = CacheConstants.PRODUCTS_ALL)
 	public List<ProductInfo.Amount> getDetailList() {
 		List<Product> productList = productRepository.getList();
 		Long[] productIds = productList.stream().map(Product::getId).toArray(Long[]::new);
@@ -36,10 +42,24 @@ public class ProductService {
 					product.getId(),
 					product.getName(),
 					product.getPrice(),
-					inventory != null ? inventory.getAmount() : 0 // 재고가 없는 경우 0 처리
+					inventory != null ? inventory.getAmount() : 0
 				);
 			})
 			.collect(Collectors.toList());
+	}
+
+	/**
+	 * <h1>제품 정보 단건조회</h1>
+	 */
+	public ProductInfo.Amount getDetail(Long productId) {
+		Product product = productRepository.getById(productId);
+		ProductInventory productInventory = productRepository.getInventoryByProductId(productId);
+		return new ProductInfo.Amount(
+			product.getId(),
+			product.getName(),
+			product.getPrice(),
+			productInventory != null ? productInventory.getAmount() : 0
+		);
 	}
 
 	/**
@@ -48,6 +68,7 @@ public class ProductService {
 	 *     <li>쿼리를 통해 group by 와 limit 를 사용해서 상위 주문 수량을 집계하였다.</li>
 	 * </ul>
 	 */
+	@Cacheable(value = CacheConstants.POPULAR_PRODUCTS_CACHE, key = CacheConstants.RECENT_3_DAY_TOP_5_KEY)
 	public List<ProductInfo.OrderAmount> getPopularProducts() {
 		return productRepository.getOrderAmountByRecent3DayAndTop5();
 	}

--- a/src/main/java/com/study/ecommerce/infra/product/ProductRepositoryImpl.java
+++ b/src/main/java/com/study/ecommerce/infra/product/ProductRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.study.ecommerce.infra.product;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,16 +25,6 @@ import lombok.RequiredArgsConstructor;
 public class ProductRepositoryImpl implements ProductRepository {
 
 	private final JPAQueryFactory queryFactory;
-	private final ProductInventoryJpaRepository productInventoryJpaRepository;
-
-	public Optional<Product> getInventory(Long id) {
-		var qProduct = QProduct.product;
-		return Optional.ofNullable(
-			queryFactory.selectFrom(qProduct)
-				.where(qProduct.id.eq(id))
-				.fetchOne()
-		);
-	}
 
 	public List<Product> getList() {
 		var qProduct = QProduct.product;
@@ -89,5 +78,21 @@ public class ProductRepositoryImpl implements ProductRepository {
 			.orderBy(qOrderItem.amount.sum().desc())
 			.limit(5)
 			.fetch();
+	}
+
+	@Override
+	public Product getById(Long productId) {
+		var qProduct = QProduct.product;
+		return queryFactory.selectFrom(qProduct)
+			.where(qProduct.id.eq(productId))
+			.fetchOne();
+	}
+
+	@Override
+	public ProductInventory getInventoryByProductId(Long productId) {
+		var qProductInventory = QProductInventory.productInventory;
+		return queryFactory.selectFrom(qProductInventory)
+			.where(qProductInventory.productId.eq(productId))
+			.fetchOne();
 	}
 }

--- a/src/main/java/com/study/ecommerce/presentation/product/ProductController.java
+++ b/src/main/java/com/study/ecommerce/presentation/product/ProductController.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.study.ecommerce.domain.product.ProductService;
@@ -34,12 +34,12 @@ public class ProductController {
 	 * 상품상세정보를 조회 한다.
 	 * @return 상품상세정보
 	 */
-	@GetMapping(params = "productId")
+	@GetMapping("{id}")
 	public ResponseEntity<ProductDto.AmountResponse> getProduct(
-		@RequestParam(name = "productId") Long productId
+		@PathVariable(name = "id") Long id
 	) {
 		return ResponseEntity.ok().body(
-			ProductDto.AmountResponse.from(productService.getDetail(productId))
+			ProductDto.AmountResponse.from(productService.getDetail(id))
 		);
 	}
 

--- a/src/main/java/com/study/ecommerce/presentation/product/ProductController.java
+++ b/src/main/java/com/study/ecommerce/presentation/product/ProductController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.study.ecommerce.domain.product.ProductService;
@@ -23,9 +24,22 @@ public class ProductController {
 	 * @return 상품상세정보 목록
 	 */
 	@GetMapping
-	public ResponseEntity<List<ProductDto.AmountResponse>> getProducts() {
+	public ResponseEntity<List<ProductDto.AmountResponse>> getProductList() {
 		return ResponseEntity.ok().body(
 			ProductDto.AmountResponse.from(productService.getDetailList())
+		);
+	}
+
+	/**
+	 * 상품상세정보를 조회 한다.
+	 * @return 상품상세정보
+	 */
+	@GetMapping(params = "productId")
+	public ResponseEntity<ProductDto.AmountResponse> getProduct(
+		@RequestParam(name = "productId") Long productId
+	) {
+		return ResponseEntity.ok().body(
+			ProductDto.AmountResponse.from(productService.getDetail(productId))
 		);
 	}
 

--- a/src/main/java/com/study/ecommerce/presentation/product/ProductDto.java
+++ b/src/main/java/com/study/ecommerce/presentation/product/ProductDto.java
@@ -22,6 +22,15 @@ public class ProductDto {
 					product.amount()
 				)).toList();
 		}
+
+		public static ProductDto.AmountResponse from(
+			ProductInfo.Amount product) {
+			return new ProductDto.AmountResponse(
+				product.id(),
+				product.name(),
+				product.price(),
+				product.amount());
+		}
 	}
 
 	public record OrderAmountResponse(

--- a/src/main/java/com/study/ecommerce/presentation/product/ProductSchedule.java
+++ b/src/main/java/com/study/ecommerce/presentation/product/ProductSchedule.java
@@ -1,0 +1,70 @@
+package com.study.ecommerce.presentation.product;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.study.ecommerce.common.constant.CacheConstants;
+import com.study.ecommerce.domain.product.Product;
+import com.study.ecommerce.domain.product.ProductInfo;
+import com.study.ecommerce.domain.product.ProductInventory;
+import com.study.ecommerce.domain.product.ProductRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+// @EnableScheduling
+@RequiredArgsConstructor
+public class ProductSchedule {
+
+	private final ProductRepository productRepository;
+	private final CacheManager cacheManager;
+
+	/**
+	 * 인기상품 조회 캐시 업데이트
+	 * 20분 간격으로 실행 (20분 = 1200000ms)
+	 */
+	@Scheduled(fixedRate = 1200000)
+	public void updatePopularProductsCache() {
+		// 새로운 데이터를 DB에서 조회
+		List<ProductInfo.OrderAmount> updatedData = productRepository.getOrderAmountByRecent3DayAndTop5();
+
+		// 캐시 덮어쓰기
+		Objects.requireNonNull(cacheManager.getCache(CacheConstants.POPULAR_PRODUCTS_CACHE))
+			.put(CacheConstants.RECENT_3_DAY_TOP_5_KEY.replace("'", ""), updatedData);
+	}
+
+	/**
+	 * 상품목록 조회 캐시 업데이트
+	 * 3분 간격으로 실행 (3분 = 180000ms)
+	 */
+	@Scheduled(fixedRate = 180000)
+	public void updateProductsCache() {
+		// 새로운 데이터를 DB에서 조회
+		List<Product> productList = productRepository.getList();
+		Long[] productIds = productList.stream().map(Product::getId).toArray(Long[]::new);
+		List<ProductInventory> productInventoryList = productRepository.getInventoryList(productIds);
+		Map<Long, ProductInventory> inventoryMap = productInventoryList.stream()
+			.collect(Collectors.toMap(ProductInventory::getProductId, inventory -> inventory));
+		List<ProductInfo.Amount> updatedData = productList.stream()
+			.map(product -> {
+				ProductInventory inventory = inventoryMap.get(product.getId());
+				return new ProductInfo.Amount(
+					product.getId(),
+					product.getName(),
+					product.getPrice(),
+					inventory != null ? inventory.getAmount() : 0
+				);
+			}).collect(Collectors.toList());
+
+		// 캐시 덮어쓰기
+		Objects.requireNonNull(cacheManager.getCache(CacheConstants.PRODUCTS_CACHE))
+			.put(CacheConstants.PRODUCTS_ALL.replace("'", ""), updatedData);
+	}
+
+}

--- a/src/main/java/com/study/ecommerce/presentation/product/ProductSchedule.java
+++ b/src/main/java/com/study/ecommerce/presentation/product/ProductSchedule.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.springframework.cache.CacheManager;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -18,7 +19,7 @@ import com.study.ecommerce.domain.product.ProductRepository;
 import lombok.RequiredArgsConstructor;
 
 @Component
-// @EnableScheduling
+@EnableScheduling
 @RequiredArgsConstructor
 public class ProductSchedule {
 

--- a/src/test/java/com/study/ecommerce/cache/ProductServiceCacheTestConstant.java
+++ b/src/test/java/com/study/ecommerce/cache/ProductServiceCacheTestConstant.java
@@ -1,0 +1,67 @@
+package com.study.ecommerce.cache;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.*;
+
+import java.util.Objects;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.data.redis.cache.RedisCacheManager;
+
+import com.study.ecommerce.common.constant.CacheConstants;
+import com.study.ecommerce.domain.product.ProductRepository;
+import com.study.ecommerce.domain.product.ProductService;
+
+@EnableCaching
+@SpringBootTest
+public class ProductServiceCacheTestConstant {
+	@SpyBean
+	private ProductRepository productRepository;
+
+	@Autowired
+	private ProductService productService;
+
+	@Autowired
+	private RedisCacheManager redisCacheManager;
+
+	@BeforeEach
+	public void setUp() {
+		openMocks(this);
+	}
+
+	@Test
+	@DisplayName("인기상품조회: 캐시가 비워져 있는 상황에서 3번 호출을 하면 DB호출은 1번만 발생한다.")
+	public void testGetPopularProductsCaching() {
+		// given
+		Objects.requireNonNull(redisCacheManager.getCache(CacheConstants.POPULAR_PRODUCTS_CACHE)).clear();
+
+		// when
+		for (int i = 0 ; i < 3; i++) {
+			productService.getPopularProducts();
+		}
+
+		// then
+		verify(productRepository, times(1)).getOrderAmountByRecent3DayAndTop5();
+	}
+
+	@Test
+	@DisplayName("상품목록조회: 캐시가 비워져 있는 상황에서 3번 호출을 하면 DB호출은 1번만 발생한다.")
+	public void testGetProductsCaching() {
+		// given
+		Objects.requireNonNull(redisCacheManager.getCache(CacheConstants.PRODUCTS_CACHE)).clear();
+
+		// when
+		for (int i = 0 ; i < 3; i++) {
+			productService.getDetailList();
+		}
+
+		// then
+		verify(productRepository, times(1)).getList();
+	}
+}


### PR DESCRIPTION
## 작업내역
- redis 관련 의존성 추가 및 Config 작업을 하엿습니다.
- Lock Aside + Write Around 전략을 사용하였고, @Cacheable 을 사용하여 캐시를 구현하였습니다.
- @SpyBean 을 사용해서 캐시적용 후 실제로 DB 조회가 1번만 되는지 확인하였습니다.
- 스케쥴링 을 통해 캐시 업데이트하도록 작업

## 리뷰 포인트
- `실시간성`과 `정확도`는 `상호 배타적인 성격`으로 인해 용도에 따라 중요도를 어디에 둘지 구분이 필요하다 판단하였습니다.
  - 따라서 아래와 같이 상품 조회 하는 API를 3가지 용도에 따라 캐시 다르게 적용하였습니다.
     1. 인기상품목록조회 : `캐싱적용(TTL: 1시간)` => `메인페이지`에 항상 보여지는 데이터
     2. 상품목록조회 :  `캐싱적용(TTL: 10분)` => `상품조회페이지`에 들어가면 보여지는 데이터
     3. 상품상세(단건조회) : `캐싱적용X` => 상품을 주문하기 위해서 `상세페이지`에 들어가면 보여지는 데이터

- 스케쥴링을 돌면서 `캐시를 업데이트`하여 `Cache Stampede 현상`을 방지하고자 하였습니다.
  - Cache Stampede 현상이 발생하지 않는 것에 대한 `테스트를 하지 못했는데 이를 검증`하려면 어떻게 해야할지 고민입니다.
  - 스케쥴러를 presentation 패키지에 두었는데 infra에 두어야하나? 생각이 들기도하는데...`어떤 패키지가 적절할지 고민`입니다.

## 바로가기
- [STEP-14 소스코드](https://github.com/onetaek/e-commerce-project/tree/STEP-14/src/main/java/com/study/ecommerce)
- [@Cacheable을 적용한 Service단 구현코드](https://github.com/onetaek/e-commerce-project/blob/STEP-14/src/main/java/com/study/ecommerce/domain/product/ProductService.java)
- [SpyBean을 사용한 캐시 테스트코드](https://github.com/onetaek/e-commerce-project/blob/STEP-14/src/test/java/com/study/ecommerce/cache/ProductServiceCacheTestConstant.java)
- [TTL 설정한 Redisconfig 설정코드](https://github.com/onetaek/e-commerce-project/blob/STEP-14/src/main/java/com/study/ecommerce/common/config/RedisConfig.java)
- [스케쥴링으로 캐시 업데이트하는 코드](https://github.com/onetaek/e-commerce-project/blob/STEP-14/src/main/java/com/study/ecommerce/presentation/product/ProductSchedule.java)
